### PR TITLE
Site id to domain name

### DIFF
--- a/api/config/common.go
+++ b/api/config/common.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/nlopes/slack"
 )
@@ -60,4 +62,66 @@ func FindBlankEnvVars(env EnvVars) []string {
 		}
 	}
 	return blanks
+}
+
+// HTTP Google Client Common Code
+
+// HTTPClient interface
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	httpClient HTTPClient
+	cache      map[string][]byte
+}
+
+// Create a new Client
+func NewClient(client HTTPClient) *Client {
+	return &Client{
+		httpClient: client,
+		cache:      map[string][]byte{},
+	}
+}
+
+// AuthorizedGet make a secure request out to the googs
+func (c *Client) AuthorizedGet(token string, url string) ([]byte, error) {
+	return c.AuthorizedGetWithCache(token, url, true)
+}
+
+// AuthorizedGetNoCache make a secure request out to the googs and always hit the live service
+func (c *Client) AuthorizedGetNoCache(token string, url string) ([]byte, error) {
+	return c.AuthorizedGetWithCache(token, url, false)
+}
+
+// AuthorizedGetWithCache make a secure request out to the googs and possibly use a cache.
+func (c *Client) AuthorizedGetWithCache(token string, url string, useCache bool) ([]byte, error) {
+
+	if body, ok := c.cache[url]; ok && useCache {
+		return body, nil
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, fmt.Errorf("authorization failed - no authorization header")
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("authorization", "Bearer "+token)
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed connecting to %s with error %s", url, err.Error())
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed read response: %s", err.Error())
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		log.Println("error from server", string(body))
+		return nil, fmt.Errorf("failed to reading from URL - status code: %d - error: %s", response.StatusCode, string(body))
+	}
+	c.cache[url] = body
+	return body, nil
 }

--- a/api/listSites/index.go
+++ b/api/listSites/index.go
@@ -1,0 +1,85 @@
+package listSites
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/kelseyhightower/envconfig"
+
+	common "github.com/searchspring/nebo/api/config"
+	"github.com/searchspring/nebo/nextopia"
+	"github.com/searchspring/nebo/salesforce"
+)
+
+var salesForceDAO salesforce.DAO = nil
+var nextopiaDAO nextopia.DAO = nil
+
+var router *mux.Router
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	if router == nil {
+		r, err := CreateRouter()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		router = r
+	}
+	router.ServeHTTP(w, r)
+}
+
+func CreateRouter() (*mux.Router, error) {
+	router := mux.NewRouter()
+	router.HandleFunc("/listSites", wrapGetSitesList(GetSitesList)).Methods(http.MethodGet, http.MethodOptions)
+	router.Use(mux.CORSMethodMiddleware(router))
+	return router, nil
+}
+
+func wrapGetSitesList(apiRequest func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			return
+		}
+		apiRequest(w, r)
+	}
+}
+
+// Handler - check routing and call correct methods
+func GetSitesList(w http.ResponseWriter, r *http.Request) {
+	var env common.EnvVars
+	err := envconfig.Process("", &env)
+	if err != nil {
+		common.SendInternalServerError(w, err)
+		return
+	}
+
+	blanks := common.FindBlankEnvVars(env)
+	if len(blanks) > 0 {
+		err := fmt.Errorf("the following env vars are blank: %s", strings.Join(blanks, ", "))
+		if env.DevMode != "development" {
+			common.SendInternalServerError(w, err)
+			return
+		}
+		log.Print(err.Error())
+	}
+
+	nextopiaDAO = nextopia.NewDAO(env.NxUser, env.NxPassword)
+	salesForceDAO = salesforce.NewDAO(env.SfURL, env.SfUser, env.SfPassword, env.SfToken)
+
+	listOfSites, err := salesForceDAO.DomainQuery()
+	if err != nil {
+		common.SendInternalServerError(w, err)
+		return
+	}
+
+	//fmt.Fprintln(w, "Domains: ", siteIdAndDomains)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	w.Write(listOfSites)
+
+}

--- a/api/listSites/index.go
+++ b/api/listSites/index.go
@@ -10,17 +10,30 @@ import (
 	"github.com/kelseyhightower/envconfig"
 
 	common "github.com/searchspring/nebo/api/config"
-	"github.com/searchspring/nebo/nextopia"
 	"github.com/searchspring/nebo/salesforce"
 	"github.com/searchspring/nebo/google"
 )
 
-var salesForceDAO salesforce.DAO = nil
-var nextopiaDAO nextopia.DAO = nil
-
 var router *mux.Router
+var env common.EnvVars
 
 func Handler(w http.ResponseWriter, r *http.Request) {
+	err := envconfig.Process("", &env)
+	if err != nil {
+		common.SendInternalServerError(w, err)
+		return
+	}
+
+	blanks := common.FindBlankEnvVars(env)
+	if len(blanks) > 0 {
+		err := fmt.Errorf("the following env vars are blank: %s", strings.Join(blanks, ", "))
+		if env.DevMode != "development" {
+			common.SendInternalServerError(w, err)
+			return
+		}
+		log.Println(err.Error())
+	}
+
 	if router == nil {
 		r, err := CreateRouter()
 		if err != nil {
@@ -35,12 +48,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 func CreateRouter() (*mux.Router, error) {
 	router := mux.NewRouter()
 	googleDAO := google.NewDAO(common.NewClient(&http.Client{}))
-	router.HandleFunc("/listSites", wrapGetSitesList(googleDAO.CheckUserLoggedIn, GetSitesList)).Methods(http.MethodGet, http.MethodOptions)
+	salesforceDAOReal := salesforce.NewDAO(env.SfURL, env.SfUser, env.SfPassword, env.SfToken)
+	router.HandleFunc("/listSites", wrapWithAuthorizedCheck(googleDAO.CheckUserLoggedIn, GetSitesList, salesforceDAOReal)).Methods(http.MethodGet, http.MethodOptions)
 	router.Use(mux.CORSMethodMiddleware(router))
 	return router, nil
 }
 
-func wrapGetSitesList(checkUserLoggedIn func(authorizationToken string) (string, error), apiRequest func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+func wrapWithAuthorizedCheck(checkUserLoggedIn func(authorizationToken string) (string, error), apiRequest func(w http.ResponseWriter, r *http.Request, salesforceDAOReal salesforce.DAO), salesforceDAOReal salesforce.DAO) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
@@ -58,40 +72,20 @@ func wrapGetSitesList(checkUserLoggedIn func(authorizationToken string) (string,
 				return
 			}
 			
-			apiRequest(w, r)
+			apiRequest(w, r, salesforceDAOReal)
 		}
 	}
 }
 
 // Handler - check routing and call correct methods
-func GetSitesList(w http.ResponseWriter, r *http.Request) {
-	var env common.EnvVars
-	err := envconfig.Process("", &env)
+func GetSitesList(w http.ResponseWriter, r *http.Request, salesforceApi salesforce.DAO) {
+
+	listOfSites, err := salesforceApi.DomainQuery()
 	if err != nil {
 		common.SendInternalServerError(w, err)
 		return
 	}
 
-	blanks := common.FindBlankEnvVars(env)
-	if len(blanks) > 0 {
-		err := fmt.Errorf("the following env vars are blank: %s", strings.Join(blanks, ", "))
-		if env.DevMode != "development" {
-			common.SendInternalServerError(w, err)
-			return
-		}
-		log.Print(err.Error())
-	}
-
-	nextopiaDAO = nextopia.NewDAO(env.NxUser, env.NxPassword)
-	salesForceDAO = salesforce.NewDAO(env.SfURL, env.SfUser, env.SfPassword, env.SfToken)
-
-	listOfSites, err := salesForceDAO.DomainQuery()
-	if err != nil {
-		common.SendInternalServerError(w, err)
-		return
-	}
-
-	//fmt.Fprintln(w, "Domains: ", siteIdAndDomains)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	w.Write(listOfSites)

--- a/api/listSites/index_test.go
+++ b/api/listSites/index_test.go
@@ -1,0 +1,18 @@
+package listSites
+
+import (
+	"testing"
+
+	common "github.com/searchspring/nebo/api/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBlankEnvVars(t *testing.T) {
+	testVars := common.EnvVars{
+		DevMode: "test",
+	}
+	blanks := common.FindBlankEnvVars(testVars)
+	for _, b := range blanks {
+		require.NotEqual(t, "DevMode", b)
+	}
+}

--- a/api/listSites/index_test.go
+++ b/api/listSites/index_test.go
@@ -1,9 +1,12 @@
 package listSites
 
 import (
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	common "github.com/searchspring/nebo/api/config"
+	mocks "github.com/searchspring/nebo/api/tests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,4 +18,13 @@ func TestFindBlankEnvVars(t *testing.T) {
 	for _, b := range blanks {
 		require.NotEqual(t, "DevMode", b)
 	}
+}
+
+func TestGetSitesList(t *testing.T) {
+	os.Setenv("DEV_MODE", "development")
+	defer os.Setenv("DEV_MODE", "")
+	w := httptest.NewRecorder()
+	sfdao := &mocks.SalesforceDAO{}
+	GetSitesList(w, httptest.NewRequest("GET", "localhost:3000/listSites", nil), sfdao)
+	require.Equal(t, 201, w.Result().StatusCode)
 }

--- a/api/nps/index.go
+++ b/api/nps/index.go
@@ -28,7 +28,7 @@ type NpsMessage struct {
 var router *mux.Router
 var env common.EnvVars
 
-var decoder = schema.NewDecoder()
+var decoder = schema.NewDecoder()  
 
 func Handler(w http.ResponseWriter, r *http.Request) {
 	err := envconfig.Process("", &env)

--- a/api/tests/mocks.go
+++ b/api/tests/mocks.go
@@ -27,9 +27,9 @@ func (s *SalesforceDAO) StructFromResult(search string, result *simpleforce.Quer
 }
 func (s *SalesforceDAO) Query(search string) ([]byte, error)   { return []byte{}, nil }
 func (s *SalesforceDAO) IDQuery(search string) ([]byte, error) { return []byte{}, nil }
-func (s *SalesforceDAO) ResultToMessage(search string, result *simpleforce.QueryResult) ([]byte, error) {
-	return []byte{}, nil
-}
+func (s *SalesforceDAO) DomainQuery() ([]byte, error) { return []byte{}, nil }
+func (s *SalesforceDAO) ResultToStruct(result *simpleforce.QueryResult) ([]byte, error) {return []byte{}, nil}
+func (s *SalesforceDAO) ResultToMessage(search string, result *simpleforce.QueryResult) ([]byte, error) {return []byte{}, nil}
 
 type SlackDAO struct {
 	Recorded []string

--- a/google/dao.go
+++ b/google/dao.go
@@ -30,6 +30,7 @@ func (d *DAOImpl) CheckUserLoggedIn(token string) (string, error) {
 	}
 	user := &emailHolder{}
 	fmt.Println("EMAIL: ", user.Email)
+	
 	err = json.Unmarshal(body, user)
 	if err != nil {
 		return "", err

--- a/google/dao.go
+++ b/google/dao.go
@@ -1,0 +1,38 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+
+	common "github.com/searchspring/nebo/api/config"
+)
+
+type DAO interface {
+	CheckUserLoggedIn(token string) (string, error)
+}
+type DAOImpl struct {
+	Client *common.Client
+}
+
+func NewDAO(client *common.Client) DAO {
+	return &DAOImpl{
+		Client: client,
+	}
+}
+
+func (d *DAOImpl) CheckUserLoggedIn(token string) (string, error) {
+	body, err := d.Client.AuthorizedGet(token, "https://www.googleapis.com/oauth2/v2/userinfo?access_token="+token)
+	if err != nil {
+		return "", err
+	}
+	type emailHolder struct {
+		Email string `json:"email"`
+	}
+	user := &emailHolder{}
+	fmt.Println("EMAIL: ", user.Email)
+	err = json.Unmarshal(body, user)
+	if err != nil {
+		return "", err
+	}
+	return user.Email, nil
+} 

--- a/salesforce/dao.go
+++ b/salesforce/dao.go
@@ -45,6 +45,11 @@ type AccountInfo struct {
 	State       string
 }
 
+type DomainAndID struct {
+	Website string
+	SiteId  string
+}
+
 // DAO acts as the salesforce DAO
 type DAO interface {
 	Query(query string) ([]byte, error)
@@ -53,6 +58,8 @@ type DAO interface {
 	NPSQuery(query string) ([]*AccountInfo, error)
 	StructFromResult(query string, result *simpleforce.QueryResult) ([]*AccountInfo, error)
 	GetSearchKey() string
+	DomainQuery() ([]byte, error)
+	ResultToStruct(result *simpleforce.QueryResult) ([]byte, error)
 }
 
 // DAOImpl defines the properties of the DAO
@@ -61,6 +68,7 @@ type DAOImpl struct {
 }
 
 const selectFields = "Type, Website, CS_Manager__r.Name, Family_MRR__c, Chargify_MRR__c, Platform__c, Integration_Type__c, Chargify_Source__c, Tracking_Code__c, BillingCity, BillingCountry, BillingState"
+const domainFields = "Website, Tracking_Code__c"
 
 // NewDAO returns the salesforce DAO
 func NewDAO(sfURL string, sfUser string, sfPassword string, sfToken string) DAO {
@@ -116,6 +124,29 @@ func (s *DAOImpl) IDQuery(search string) ([]byte, error) {
 		return nil, err
 	}
 	return s.ResultToMessage(sanitized, result)
+}
+
+func (s *DAOImpl) DomainQuery() ([]byte, error) {
+
+	q := "SELECT " + domainFields + " " + "FROM Account"
+	result, err := s.Client.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	return s.ResultToStruct(result)
+}
+
+func (s *DAOImpl) ResultToStruct(result *simpleforce.QueryResult) ([]byte, error) {
+	accounts := []*DomainAndID{}
+	for _, record := range result.Records {
+		if record["Tracking_Code__c"] != nil {
+			accounts = append(accounts, &DomainAndID{
+				Website:     fmt.Sprintf("%s", record["Website"]),
+				SiteId: fmt.Sprintf("%s", record["Tracking_Code__c"]),
+			})
+		}
+	}
+	return json.Marshal(accounts)
 }
 
 func (s *DAOImpl) ResultToMessage(search string, result *simpleforce.QueryResult) ([]byte, error) {
@@ -233,10 +264,10 @@ func (s *DAOImpl) StructFromResult(search string, result *simpleforce.QueryResul
 		}
 
 		accounts = append(accounts, &AccountInfo{
-			Manager:     managerName,
-			Active:      active,
-			MRR:         mrr,
-			FamilyMRR:   familymrr,
+			Manager:   managerName,
+			Active:    active,
+			MRR:       mrr,
+			FamilyMRR: familymrr,
 		})
 	}
 	accounts = cleanAccounts(accounts)
@@ -331,4 +362,3 @@ func sortAccounts(accounts []*AccountInfo) []*AccountInfo {
 	})
 	return accounts
 }
-

--- a/salesforce/dao.go
+++ b/salesforce/dao.go
@@ -46,8 +46,8 @@ type AccountInfo struct {
 }
 
 type DomainAndID struct {
-	Website string
-	SiteId  string
+	Website string 
+	SiteId  string 
 }
 
 // DAO acts as the salesforce DAO
@@ -140,9 +140,10 @@ func (s *DAOImpl) ResultToStruct(result *simpleforce.QueryResult) ([]byte, error
 	accounts := []*DomainAndID{}
 	for _, record := range result.Records {
 		if record["Tracking_Code__c"] != nil {
+			siteId := fmt.Sprintf("%s", record["Tracking_Code__c"])
 			accounts = append(accounts, &DomainAndID{
 				Website:     fmt.Sprintf("%s", record["Website"]),
-				SiteId: fmt.Sprintf("%s", record["Tracking_Code__c"]),
+				SiteId: strings.ToLower(siteId),
 			})
 		}
 	}

--- a/salesforce/dao.go
+++ b/salesforce/dao.go
@@ -189,7 +189,7 @@ func (s *DAOImpl) ResultToMessage(search string, result *simpleforce.QueryResult
 			siteId = fmt.Sprintf("%s", record["Tracking_Code__c"])
 		}
 		city := "unknown"
-		state := "state"
+		state := "unknown"
 		if record["BillingCity"] != nil && record["BillingState"] != nil {
 			city = fmt.Sprintf("%s", record["BillingCity"])
 			state = fmt.Sprintf("%s", record["BillingState"])
@@ -329,7 +329,11 @@ func formatAccountInfos(accountInfos []*AccountInfo, search string) *slack.Msg {
 			familymrr = p.Sprintf("$%.2f", ai.FamilyMRR)
 		}
 		mrr = mrr + " (Family MRR: " + familymrr + ")"
-		loc := ai.City + ", " + ai.State
+		loc := ai.City
+		if ai.State != "unknown" {
+			loc += ", " + ai.State
+		} 
+		loc = ai.City + ", " + ai.State
 		text := "Rep: " + ai.Manager + "\nMRR: " + mrr + "\nPlatform: " + ai.Platform + "\nIntegration: " + ai.Integration + "\nProvider: " + ai.Provider + "\nLocation: " + loc
 		msg.Attachments = append(msg.Attachments, slack.Attachment{
 			Color:      "#" + color,

--- a/salesforce/dao_test.go
+++ b/salesforce/dao_test.go
@@ -29,6 +29,18 @@ func createQueryResults() *simpleforce.QueryResult {
 	return qr
 }
 
+func createDomainQueryResults() *simpleforce.QueryResult {
+	qr := &simpleforce.QueryResult{}
+	json.Unmarshal([]byte(`{ "totalSize": 1,
+        "done": true,
+        "records": [{ 
+                "Website": "fabletics.com",
+                "Tracking_Code__c": "wub9gl"} 
+            ]
+        }`), qr)
+	return qr
+}
+
 func TestFormatAccountInfos(t *testing.T) {
 	dao := &DAOImpl{}
 	response, err := dao.ResultToMessage("search term", createQueryResults())
@@ -46,6 +58,18 @@ func TestFormatAccountInfos(t *testing.T) {
 	require.Contains(t, msg.Attachments[0].Text, "Location: Chicago, IL")
 	require.Equal(t, "fabletics.com (Not active) (SiteId: wub9gl)", msg.Attachments[0].AuthorName)
 	require.Equal(t, "#3A23AD", msg.Attachments[0].Color)
+}
+
+func TestResultToStruct(t *testing.T) {
+	dao := &DAOImpl{}
+	response, err := dao.ResultToStruct(createDomainQueryResults())
+	require.Nil(t, err)
+	data := &[]DomainAndID{}
+	err = json.Unmarshal(response, data)
+	require.Nil(t, err)
+	require.Contains(t, (*data)[0].Website, "fabletics.com")
+	require.Contains(t, (*data)[0].SiteId, "wub9gl")
+
 }
 
 func c(b []byte, e error) string {

--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,10 @@
     {
       "src": "api/slackEvents/index.go", 
       "use": "@vercel/go"
+    },
+    {
+      "src": "api/listSites/index.go", 
+      "use": "@vercel/go"
     }
   ],
   "routes": [
@@ -38,6 +42,10 @@
     {
       "src": "/slackEvents",
       "dest": "/api/slackEvents"
+    },
+    {
+      "src": "/listSites",
+      "dest": "/api/listSites"
     }
   ]
 }


### PR DESCRIPTION
This PR includes the new endpoint `/listSites` that responds with an array with all the SiteId's and Domain Names queried from SalesForce. 

This endpoint is secured by the GoogleDAO which was also added in this PR and requires an authorization header with the proper token to return the data requested. 

The endpoint has been tested for security with both no-token and an invalid token and has successfully denied access in both instances. 