### PR TITLE
Check for Prospect Customer

### DIFF
--- a/dals/salesforce/salesforce.go
+++ b/dals/salesforce/salesforce.go
@@ -53,8 +53,7 @@ func (s *DAOImpl) Query(search string) ([]*models.AccountInfo, error) {
 	sanitized := reg.ReplaceAllString(search, "")
 
 	q := "SELECT " + selectFields + " " +
-		"FROM Account WHERE Type IN ('Customer', 'Inactive Customer') " +
-		"AND (Website LIKE '%" + sanitized + "%' OR Platform__c LIKE '%" + sanitized +
+		"FROM Account WHERE (Website LIKE '%" + sanitized + "%' OR Platform__c LIKE '%" + sanitized +
 		"%' OR Tracking_Code__c = '" + sanitized + "') ORDER BY Chargify_MRR__c DESC"
 	result, err := s.Client.Query(q)
 	if err != nil {
@@ -73,7 +72,7 @@ func (s *DAOImpl) ResultToMessage(search string, result *simpleforce.QueryResult
 				managerName = fmt.Sprintf("%s", mapName)
 			}
 		}
-		Type := record["Type"]
+		Type := fmt.Sprintf("%s", record["Type"])
 		active := "Active"
 		if Type != "Customer" {
 			active = "Not active"
@@ -113,6 +112,7 @@ func (s *DAOImpl) ResultToMessage(search string, result *simpleforce.QueryResult
 			Website:     fmt.Sprintf("%s", record["Website"]),
 			Manager:     managerName,
 			Active:      active,
+			Type:        Type,
 			MRR:         mrr,
 			FamilyMRR:   familymrr,
 			Platform:    platform,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/grokify/go-metabase v0.0.1
 	github.com/grokify/oauth2more v0.4.4
-	github.com/grokify/simplego v0.0.22
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nlopes/slack v0.6.0
 	github.com/simpleforce/simpleforce v0.0.0-20201016131803-2062cbbdbb89

--- a/models/accounts.go
+++ b/models/accounts.go
@@ -1,10 +1,10 @@
 package models
 
-
 type AccountInfo struct {
 	Website     string
 	Manager     string
 	Active      string
+	Type        string
 	MRR         float64
 	FamilyMRR   float64
 	Platform    string

--- a/services/aggregate/aggregate.go
+++ b/services/aggregate/aggregate.go
@@ -41,7 +41,7 @@ func (d *AggregateServiceImpl) Query(search string) ([]byte, error) {
 	if !isPlatformSearch(search) {
 		aggregatedData = sortAccounts(aggregatedData, "website")
 	}
-	aggregatedData = truncateAccounts(aggregatedData)
+	aggregatedData = truncateToTwenty(aggregatedData)
 	aggregatedData = sortAccounts(aggregatedData, "mrr")
 
 	msg := common.FormatAccountInfos(aggregatedData, search)
@@ -88,7 +88,7 @@ func exists(id string, website string, data []*models.AccountInfo) (result bool,
 
 // cleaning account arrays
 
-func truncateAccounts(accounts []*models.AccountInfo) []*models.AccountInfo {
+func truncateToTwenty(accounts []*models.AccountInfo) []*models.AccountInfo {
 	truncated := []*models.AccountInfo{}
 	for i, account := range accounts {
 		if i == 20 {

--- a/services/aggregate/aggregate.go
+++ b/services/aggregate/aggregate.go
@@ -36,12 +36,13 @@ func (d *AggregateServiceImpl) Query(search string) ([]byte, error) {
 		return nil, nil
 	}
 
+	/* add all metabase data to the final array that A) Doesn't have a corrisponding document in SF
+	   B) Has a corrisponding document in SF as long as the SF document is of type Customer or Inactive Customer
+	*/
 	for _, v := range metabaseData {
 		e, i := exists(v.SiteId, v.Website, salesforceData)
 		if e {
-			if salesforceData[i].Type == "Prospect" {
-				continue
-			} else {
+			if salesforceData[i].Type == "Customer" || salesforceData[i].Type == "Inactive Customer" {
 				aggregatedData = append(aggregatedData, v)
 			}
 		} else {
@@ -49,10 +50,11 @@ func (d *AggregateServiceImpl) Query(search string) ([]byte, error) {
 		}
 	}
 
+	// add all salesforce data to the final array that doesn't already exist in the final array and is of type Customer or Inactive Customer
 	for _, v := range salesforceData {
 		e, _ := exists(v.SiteId, v.Website, aggregatedData) 
 		if !e {
-			if v.Type != "Prospect" {
+			if v.Type == "Customer" || v.Type == "Inactive Customer" {
 				aggregatedData = append(aggregatedData, v)
 			}
 		}

--- a/services/aggregate/aggregate_test.go
+++ b/services/aggregate/aggregate_test.go
@@ -1,0 +1,67 @@
+package aggregate
+
+import (
+	"testing"
+
+	"github.com/searchspring/nebo/models"
+	"github.com/stretchr/testify/require"
+)
+
+func metabaseCustomers() []*models.AccountInfo {
+	return []*models.AccountInfo{
+		{
+			SiteId:  "123456",
+			Website: "one.com",
+		},
+		{
+			SiteId:  "abcdef",
+			Website: "two.com",
+		},
+	}
+}
+
+func salesforceCustomers() []*models.AccountInfo {
+	return []*models.AccountInfo{
+		{
+			Type:    "Customer",
+			SiteId:  "123abc",
+			Website: "three.com",
+		},
+		{
+			Type:    "Prospect",
+			SiteId:  "123456",
+			Website: "one.com",
+		},
+	}
+}
+
+func TestAddingMetabaseAccounts(t *testing.T) {
+	metabaseAccounts := addMetabaseAccounts(metabaseCustomers(), salesforceCustomers())
+
+	require.Equal(t, 1, len(metabaseAccounts))
+	require.Equal(t, "abcdef", metabaseAccounts[0].SiteId)
+	require.Equal(t, "two.com", metabaseAccounts[0].Website)
+}
+
+func TestAddingSalesforceAccounts(t *testing.T) {
+	combinedAccounts := addSalesforceAccounts(metabaseCustomers(), salesforceCustomers())
+
+	require.Equal(t, 3, len(combinedAccounts))
+	require.Equal(t, "123456", combinedAccounts[0].SiteId)
+	require.Equal(t, "one.com", combinedAccounts[0].Website)
+	require.Equal(t, "abcdef", combinedAccounts[1].SiteId)
+	require.Equal(t, "two.com", combinedAccounts[1].Website)
+	require.Equal(t, "123abc", combinedAccounts[2].SiteId)
+	require.Equal(t, "three.com", combinedAccounts[2].Website)
+}
+
+func TestAddingSFAndMBAccounts(t *testing.T) {
+	combinedAccounts := addMetabaseAccounts(metabaseCustomers(), salesforceCustomers())
+	combinedAccounts = addSalesforceAccounts(combinedAccounts, salesforceCustomers())
+
+	require.Equal(t, 2, len(combinedAccounts))
+	require.Equal(t, "abcdef", combinedAccounts[0].SiteId)
+	require.Equal(t, "two.com", combinedAccounts[0].Website)
+	require.Equal(t, "123abc", combinedAccounts[1].SiteId)
+	require.Equal(t, "three.com", combinedAccounts[1].Website)
+}


### PR DESCRIPTION
This PR fixes the error where the customers who are only prospects can be displayed from Metabase since there is no field that specifies prospect or not. 

The Salesforce query was adjusted to return all customers, prospect or not, and now if a match is found between the 2 databases and the Salesforce marks it as a prospect, neither the SF nor MB entry will be displayed in the slack response.

This has been tested with various examples including the one that Peter noticed to be the problem in the first place and seems to be working now.
